### PR TITLE
Correction when generating without file name. Extension was duplicated

### DIFF
--- a/swagger-csv/SwaggerToCSV.cs
+++ b/swagger-csv/SwaggerToCSV.cs
@@ -87,9 +87,9 @@ namespace swagger_csv
             {
                 this.Output += $"swagger-csv-{ DateTime.Now:yyyyMMdd-HHmmss}.csv";
             }
-            else if (string.IsNullOrEmpty(extension) || extension.Equals(csvExtension, StringComparison.InvariantCultureIgnoreCase))
+            else if (string.IsNullOrEmpty(extension) || !extension.Equals(csvExtension, StringComparison.InvariantCultureIgnoreCase))
             {
-                this.Output += ".csv";
+                this.Output = Path.ChangeExtension(this.Output, csvExtension);
             }
 
             using (var sw = new StreamWriter(this.Output, false, Encoding.UTF8))


### PR DESCRIPTION
- Erro ao fazer a exportação sem colocar um nome de arquivo. A extensão ficava duplicada.